### PR TITLE
Rename flagType to flagSourceType

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ class DevelopAnnotationAdapter : AnnotationAdapter<DevelopWith> {
     return env[ENV_IS_DEVELOP_KEY] == true
   }
 
-  override fun flagType(annotation: DevelopWith): KClass<out FlagSource> {
+  override fun flagSourceType(annotation: DevelopWith): KClass<out FlagSource> {
     return annotation.value
   }
 

--- a/flagfit-flagtype/src/main/java/tv/abema/flagfit/FlagType.kt
+++ b/flagfit-flagtype/src/main/java/tv/abema/flagfit/FlagType.kt
@@ -39,7 +39,7 @@ class FlagType {
       return true
     }
 
-    override fun flagType(annotation: WorkInProgress): KClass<JustFlagSource.False> {
+    override fun flagSourceType(annotation: WorkInProgress): KClass<JustFlagSource.False> {
       return JustFlagSource.False::class
     }
 
@@ -56,7 +56,7 @@ class FlagType {
       return true
     }
 
-    override fun flagType(annotation: Ops): KClass<OpsFlagSource> {
+    override fun flagSourceType(annotation: Ops): KClass<OpsFlagSource> {
       return OpsFlagSource::class
     }
 
@@ -73,7 +73,7 @@ class FlagType {
       return true
     }
 
-    override fun flagType(annotation: Experiment): KClass<ExperimentFlagSource> {
+    override fun flagSourceType(annotation: Experiment): KClass<ExperimentFlagSource> {
       return ExperimentFlagSource::class
     }
 
@@ -90,7 +90,7 @@ class FlagType {
       return true
     }
 
-    override fun flagType(annotation: Permission): KClass<PermissionFlagSource> {
+    override fun flagSourceType(annotation: Permission): KClass<PermissionFlagSource> {
       return PermissionFlagSource::class
     }
 

--- a/flagfit/src/main/java/tv/abema/flagfit/AnnotationAdapter.kt
+++ b/flagfit/src/main/java/tv/abema/flagfit/AnnotationAdapter.kt
@@ -5,5 +5,5 @@ import kotlin.reflect.KClass
 interface AnnotationAdapter<T : Annotation> {
   fun annotationClass(): KClass<T>
   fun canHandle(annotation: T, env: Map<String, Any>): Boolean
-  fun flagType(annotation: T): KClass<out FlagSource>
+  fun flagSourceType(annotation: T): KClass<out FlagSource>
 }

--- a/flagfit/src/main/java/tv/abema/flagfit/DebugAnnotationAdapter.kt
+++ b/flagfit/src/main/java/tv/abema/flagfit/DebugAnnotationAdapter.kt
@@ -11,7 +11,7 @@ class DebugAnnotationAdapter : AnnotationAdapter<DebugWith> {
     return env[Flagfit.ENV_IS_DEBUG_KEY] == true
   }
 
-  override fun flagType(annotation: DebugWith): KClass<out FlagSource> {
+  override fun flagSourceType(annotation: DebugWith): KClass<out FlagSource> {
     return annotation.value
   }
 

--- a/flagfit/src/main/java/tv/abema/flagfit/DefaultAnnotationAdapter.kt
+++ b/flagfit/src/main/java/tv/abema/flagfit/DefaultAnnotationAdapter.kt
@@ -11,7 +11,7 @@ class DefaultAnnotationAdapter : AnnotationAdapter<DefaultWith> {
     return true
   }
 
-  override fun flagType(annotation: DefaultWith): KClass<out FlagSource> {
+  override fun flagSourceType(annotation: DefaultWith): KClass<out FlagSource> {
     return annotation.value
   }
 

--- a/flagfit/src/main/java/tv/abema/flagfit/Flagfit.kt
+++ b/flagfit/src/main/java/tv/abema/flagfit/Flagfit.kt
@@ -216,7 +216,7 @@ class Flagfit(
       val env = baseEnv + annotationBooleanEnvList
         .associate { it.key to it.value }
 
-      var annotatedFlagType: Class<out FlagSource>? = null
+      var annotatedFlagSourceType: Class<out FlagSource>? = null
       for (annotationAdapter in annotationAdapters) {
         val annotationClass = annotationAdapter.annotationClass().java
 
@@ -227,17 +227,17 @@ class Flagfit(
         @Suppress("UNCHECKED_CAST")
         val adapter = annotationAdapter as AnnotationAdapter<Annotation>
         if (adapter.canHandle(annotation, env)) {
-          annotatedFlagType = adapter.flagType(annotation).java
+          annotatedFlagSourceType = adapter.flagSourceType(annotation).java
           break
         }
       }
 
-      val flagSource = annotatedFlagType?.let {
+      val flagSource = annotatedFlagSourceType?.let {
         try {
-          getFlagSourceByClass(annotatedFlagType)
+          getFlagSourceByClass(annotatedFlagSourceType)
         } catch (e: NoSuchElementException) {
           throw IllegalArgumentException(
-            "Flag source($annotatedFlagType) not found for method: ${method.name}"
+            "Flag source($annotatedFlagSourceType) not found for method: ${method.name}"
           )
         }
       }

--- a/flagfit/src/main/java/tv/abema/flagfit/ReleaseAnnotationAdapter.kt
+++ b/flagfit/src/main/java/tv/abema/flagfit/ReleaseAnnotationAdapter.kt
@@ -11,7 +11,7 @@ class ReleaseAnnotationAdapter : AnnotationAdapter<ReleaseWith> {
     return env[Flagfit.ENV_IS_DEBUG_KEY] == false
   }
 
-  override fun flagType(annotation: ReleaseWith): KClass<out FlagSource> {
+  override fun flagSourceType(annotation: ReleaseWith): KClass<out FlagSource> {
     return annotation.value
   }
 

--- a/flagfit/src/test/java/tv/abema/flagfit/FlagfitTest.kt
+++ b/flagfit/src/test/java/tv/abema/flagfit/FlagfitTest.kt
@@ -419,7 +419,7 @@ class DevelopAnnotationAdapter : AnnotationAdapter<DevelopWith> {
     return env[ENV_IS_DEVELOP_KEY] == true
   }
 
-  override fun flagType(annotation: DevelopWith): KClass<out FlagSource> {
+  override fun flagSourceType(annotation: DevelopWith): KClass<out FlagSource> {
     return annotation.flagType
   }
 


### PR DESCRIPTION
The name `flagType` is easily confused with the `flagtype` module, so we renamed it to the more explicit flagSourceType.