### PR TITLE
Put ProGuard rules

### DIFF
--- a/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
+++ b/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
@@ -1,0 +1,2 @@
+-keep class tv.abema.flagfit.annotation.**
+-keep class tv.abema.flagfit.SuspendReturnType


### PR DESCRIPTION
It is necessary to add rules when using ProGuard's optimization settings.
This PR bundles the rules into a library.