### PR TITLE
Changed so that fallback OWNER is set if assignment fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,5 +477,5 @@ Flags that have passed their expiration date will be automatically created as is
 - Please copy the [workflow](./.github/workflows/lintIssues.yml) and [script](./scripts/maintain-flagfit-expiration-issue.main.kts) to the project you are using.
 - The workflow allows you to set a cron schedule, so please set it as appropriate.
 - When setting feature flags with Flagfit, you will likely use `@BooleanFlag` or `@VariationFlag`, but please make sure that the key value is always unique.
-- If the flag's owner cannot be assigned to an Issue, the individual specified in [fallbackAssigneeWhenOwnerNotPresent](https://github.com/abema/flagfit/blob/update-script-fallbackAssignee/scripts/maintain-flagfit-expiration-issue.main.kts#L147) will be assigned to the Issue instead.
+- If the flag's owner cannot be assigned to an issue, the individual specified in [fallbackAssigneeWhenOwnerNotPresent](https://github.com/abema/flagfit/blob/update-script-fallbackAssignee/scripts/maintain-flagfit-expiration-issue.main.kts#L147) will be assigned to the issue instead.
 <img width="1253" alt="Sample issues" src="https://github.com/abema/flagfit/assets/51113946/e4e5715d-f77a-4ffc-abbd-429544c1c1fa">

--- a/README.md
+++ b/README.md
@@ -477,4 +477,5 @@ Flags that have passed their expiration date will be automatically created as is
 - Please copy the [workflow](./.github/workflows/lintIssues.yml) and [script](./scripts/maintain-flagfit-expiration-issue.main.kts) to the project you are using.
 - The workflow allows you to set a cron schedule, so please set it as appropriate.
 - When setting feature flags with Flagfit, you will likely use `@BooleanFlag` or `@VariationFlag`, but please make sure that the key value is always unique.
+- If the flag's owner cannot be assigned to an Issue, the individual specified in [fallbackAssigneeWhenOwnerNotPresent](https://github.com/abema/flagfit/blob/update-script-fallbackAssignee/scripts/maintain-flagfit-expiration-issue.main.kts#L147) will be assigned to the Issue instead.
 <img width="1253" alt="Sample issues" src="https://github.com/abema/flagfit/assets/51113946/e4e5715d-f77a-4ffc-abbd-429544c1c1fa">


### PR DESCRIPTION
"Previously, the application of `fallbackAssigneeWhenOwnerNotPresent` depended on whether an owner existed among the collaborators in the repository. However, we've made a change so that `fallbackAssigneeWhenOwnerNotPresent` will be applied if the assignment fails."