### PR TITLE
fix: ship R8 fullMode-correct consumer ProGuard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,12 +487,18 @@ If you can't yet upgrade to a version that ships these rules, add the following 
 your app's `proguard-rules.pro`:
 
 ```proguard
--keepattributes RuntimeVisibleAnnotations,AnnotationDefault,Signature
--keep class tv.abema.flagfit.annotation.**
--keep class tv.abema.flagfit.SuspendReturnType
--keep class tv.abema.flagfit.FlagType
--keep class tv.abema.flagfit.FlagType$* { *; }
--keep class * extends tv.abema.flagfit.FlagSource
+-keepattributes RuntimeVisibleAnnotations
+
+-keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanFlag
+-keep,allowobfuscation class tv.abema.flagfit.annotation.VariationFlag
+-keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanEnv
+-keep,allowobfuscation class tv.abema.flagfit.annotation.DebugWith
+-keep,allowobfuscation class tv.abema.flagfit.annotation.ReleaseWith
+-keep,allowobfuscation class tv.abema.flagfit.annotation.DefaultWith
+-keep,allowobfuscation class tv.abema.flagfit.SuspendReturnType
+-keep,allowobfuscation class tv.abema.flagfit.FlagType
+-keep,allowobfuscation class tv.abema.flagfit.FlagType$* { *; }
+-keep,allowobfuscation class * extends tv.abema.flagfit.FlagSource
 
 -if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
 -keep,allowobfuscation interface <1>

--- a/README.md
+++ b/README.md
@@ -462,6 +462,44 @@ val flagfit = Flagfit(
 )
 ```
 
+## R8 / ProGuard
+
+Flagfit uses `Proxy.newProxyInstance` and reads each interface method's annotations
+via reflection at runtime. To keep this working under code shrinking — including
+**R8 fullMode**, which is the default since AGP 8.0 — both `flagfit` and
+`flagfit-flagtype` ship consumer ProGuard rules in their `META-INF/proguard/`
+directory.
+
+If you depend on `flagfit:1.1.8` (or newer) and `flagfit-flagtype:1.1.8` (or newer)
+no extra app-side configuration is required — the bundled rules already keep:
+
+- the flagfit annotation classes (`@BooleanFlag`, `@VariationFlag`, `@BooleanEnv`,
+  `@DebugWith`, `@ReleaseWith`, `@DefaultWith`) and their runtime values,
+- any interface that declares a flagfit-annotated method (so `Flagfit.create()`'s
+  proxy + `declaredMethods` reflection still works after shrinking),
+- every `FlagSource` subclass referenced via `@DebugWith` / `@ReleaseWith` /
+  `@DefaultWith` annotation values,
+- `FlagType` and all its inner annotation / `AnnotationAdapter` classes.
+
+### Workaround for older versions
+
+If you can't yet upgrade to a version that ships these rules, add the following to
+your app's `proguard-rules.pro`:
+
+```proguard
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault,Signature
+-keep class tv.abema.flagfit.annotation.**
+-keep class tv.abema.flagfit.SuspendReturnType
+-keep class tv.abema.flagfit.FlagType
+-keep class tv.abema.flagfit.FlagType$* { *; }
+-keep class * extends tv.abema.flagfit.FlagSource
+
+-if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
+-keep,allowobfuscation interface <1>
+-if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
+-keep,allowobfuscation interface <1>
+```
+
 ## Lint check based on expiration date
 
 Flags that have passed their expiration date or are scheduled to expire within the next 7 days will be displayed as warnings in the IDE.

--- a/README.md
+++ b/README.md
@@ -464,64 +464,9 @@ val flagfit = Flagfit(
 
 ## R8 / ProGuard
 
-Flagfit uses `Proxy.newProxyInstance` and reads each interface method's annotations
-via reflection at runtime. To keep this working under code shrinking — including
-**R8 fullMode**, which is the default since AGP 8.0 — both `flagfit` and
-`flagfit-flagtype` ship consumer ProGuard rules in their `META-INF/proguard/`
-directory.
+If you are using R8 the shrinking and obfuscation rules are included automatically.
 
-If you depend on `flagfit:1.1.8` (or newer) and `flagfit-flagtype:1.1.8` (or newer)
-no extra app-side configuration is required — the bundled rules already keep:
-
-- the flagfit annotation classes (`@BooleanFlag`, `@VariationFlag`, `@BooleanEnv`,
-  `@DebugWith`, `@ReleaseWith`, `@DefaultWith`) and their runtime values,
-- any interface that declares a flagfit-annotated method (so `Flagfit.create()`'s
-  proxy + `declaredMethods` reflection still works after shrinking),
-- every `FlagSource` subclass referenced via `@DebugWith` / `@ReleaseWith` /
-  `@DefaultWith` annotation values,
-- `FlagType` and all its inner annotation / `AnnotationAdapter` classes.
-
-### Workaround for older versions
-
-If you can't yet upgrade to a version that ships these rules, add the following to
-your app's `proguard-rules.pro`:
-
-```proguard
--keepattributes RuntimeVisibleAnnotations
-
--keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanFlag
--keep,allowobfuscation class tv.abema.flagfit.annotation.VariationFlag
--keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanEnv
--keep,allowobfuscation class tv.abema.flagfit.annotation.DebugWith
--keep,allowobfuscation class tv.abema.flagfit.annotation.ReleaseWith
--keep,allowobfuscation class tv.abema.flagfit.annotation.DefaultWith
--keep,allowobfuscation class tv.abema.flagfit.SuspendReturnType
--keep,allowobfuscation class tv.abema.flagfit.FlagType
--keep,allowobfuscation class tv.abema.flagfit.FlagType$* { *; }
--keep,allowobfuscation class * extends tv.abema.flagfit.FlagSource
-
--if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
--keep,allowobfuscation interface <1>
--if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
--keep,allowobfuscation interface <1>
-
-# Subinterfaces of an annotated flag service must also survive R8 fullMode.
--if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
--keep,allowobfuscation interface * extends <1>
--if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
--keep,allowobfuscation interface * extends <1>
-
-# Flagfit reads each annotated method's annotations via reflection, so the
-# methods themselves must be preserved on every flag-service interface.
--keepclassmembers,allowobfuscation interface * {
-    @tv.abema.flagfit.annotation.BooleanFlag <methods>;
-    @tv.abema.flagfit.annotation.VariationFlag <methods>;
-    @tv.abema.flagfit.annotation.BooleanEnv <methods>;
-    @tv.abema.flagfit.annotation.DebugWith <methods>;
-    @tv.abema.flagfit.annotation.ReleaseWith <methods>;
-    @tv.abema.flagfit.annotation.DefaultWith <methods>;
-}
-```
+ProGuard users must manually add the options from [flagfit.pro](flagfit/src/main/resources/META-INF/proguard/flagfit.pro) and [flagfit-flagtype.pro](flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro).
 
 ## Lint check based on expiration date
 

--- a/README.md
+++ b/README.md
@@ -498,6 +498,23 @@ your app's `proguard-rules.pro`:
 -keep,allowobfuscation interface <1>
 -if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
 -keep,allowobfuscation interface <1>
+
+# Subinterfaces of an annotated flag service must also survive R8 fullMode.
+-if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
+-keep,allowobfuscation interface * extends <1>
+-if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+# Flagfit reads each annotated method's annotations via reflection, so the
+# methods themselves must be preserved on every flag-service interface.
+-keepclassmembers,allowobfuscation interface * {
+    @tv.abema.flagfit.annotation.BooleanFlag <methods>;
+    @tv.abema.flagfit.annotation.VariationFlag <methods>;
+    @tv.abema.flagfit.annotation.BooleanEnv <methods>;
+    @tv.abema.flagfit.annotation.DebugWith <methods>;
+    @tv.abema.flagfit.annotation.ReleaseWith <methods>;
+    @tv.abema.flagfit.annotation.DefaultWith <methods>;
+}
 ```
 
 ## Lint check based on expiration date

--- a/flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro
+++ b/flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro
@@ -1,6 +1,8 @@
-# FlagType outer class and all inner classes (FlagType.WorkInProgress, .Experiment,
-# .Ops, .Permission and the four *AnnotationAdapter inner classes) must survive
-# because Flagfit.create() reflects on the annotations and FlagType.annotationAdapters()
-# instantiates the adapters by name.
--keep class tv.abema.flagfit.FlagType
--keep class tv.abema.flagfit.FlagType$* { *; }
+# FlagType outer class and all inner classes (FlagType.WorkInProgress,
+# .Experiment, .Ops, .Permission and the four *AnnotationAdapter inner
+# classes) must survive because Flagfit.create() reflects on the annotations
+# and FlagType.annotationAdapters() instantiates the adapters.
+# Class literal references in user code are rewritten by R8 in lock-step,
+# so allowobfuscation is safe.
+-keep,allowobfuscation class tv.abema.flagfit.FlagType
+-keep,allowobfuscation class tv.abema.flagfit.FlagType$* { *; }

--- a/flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro
+++ b/flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro
@@ -1,0 +1,6 @@
+# FlagType outer class and all inner classes (FlagType.WorkInProgress, .Experiment,
+# .Ops, .Permission and the four *AnnotationAdapter inner classes) must survive
+# because Flagfit.create() reflects on the annotations and FlagType.annotationAdapters()
+# instantiates the adapters by name.
+-keep class tv.abema.flagfit.FlagType
+-keep class tv.abema.flagfit.FlagType$* { *; }

--- a/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
+++ b/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
@@ -16,6 +16,15 @@
 -if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
 -keep,allowobfuscation interface <1>
 
+# Also keep subinterfaces of the above, because callers may proxy a child
+# interface (e.g. `interface Child : Parent`) whose annotated methods live on
+# the parent. R8 fullMode would otherwise be free to strip / merge `Child`.
+-if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
+-if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
+-keep,allowobfuscation interface * extends <1>
+
 # Keep the annotated methods (and their annotations) on those interfaces so
 # Method.getAnnotations() returns the real values.
 -keepclassmembers,allowobfuscation interface * {

--- a/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
+++ b/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
@@ -1,2 +1,32 @@
+# Keep flagfit annotation classes themselves.
 -keep class tv.abema.flagfit.annotation.**
 -keep class tv.abema.flagfit.SuspendReturnType
+
+# Annotations must survive with their runtime values so Flagfit.create() can read
+# them via reflection at runtime.
+-keepattributes RuntimeVisibleAnnotations,AnnotationDefault,Signature
+
+# Flagfit.create() builds a JDK Proxy for any interface whose methods are annotated
+# with @BooleanFlag or @VariationFlag, then iterates declaredMethods. R8 fullMode
+# removes such interfaces because it sees no concrete implementation, so explicitly
+# keep them. (Same pattern Retrofit uses for @retrofit2.http.* methods.)
+-if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
+-keep,allowobfuscation interface <1>
+
+-if interface * { @tv.abema.flagfit.annotation.VariationFlag <methods>; }
+-keep,allowobfuscation interface <1>
+
+# Keep the annotated methods (and their annotations) on those interfaces so
+# Method.getAnnotations() returns the real values.
+-keepclassmembers,allowobfuscation interface * {
+    @tv.abema.flagfit.annotation.BooleanFlag <methods>;
+    @tv.abema.flagfit.annotation.VariationFlag <methods>;
+    @tv.abema.flagfit.annotation.BooleanEnv <methods>;
+    @tv.abema.flagfit.annotation.DebugWith <methods>;
+    @tv.abema.flagfit.annotation.ReleaseWith <methods>;
+    @tv.abema.flagfit.annotation.DefaultWith <methods>;
+}
+
+# FlagSource subclasses referenced only via @DebugWith / @ReleaseWith / @DefaultWith
+# (KClass<out FlagSource> annotation values) are otherwise unreachable.
+-keep class * extends tv.abema.flagfit.FlagSource

--- a/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
+++ b/flagfit/src/main/resources/META-INF/proguard/flagfit.pro
@@ -1,15 +1,31 @@
-# Keep flagfit annotation classes themselves.
--keep class tv.abema.flagfit.annotation.**
--keep class tv.abema.flagfit.SuspendReturnType
+# Keep flagfit annotation classes individually (avoid library-package wildcard
+# per the Android library-optimization guidance). Lookups in Flagfit.kt use
+# class literals which R8 rewrites in lock-step, so allowobfuscation is safe.
+-keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanFlag
+-keep,allowobfuscation class tv.abema.flagfit.annotation.VariationFlag
+-keep,allowobfuscation class tv.abema.flagfit.annotation.BooleanEnv
+-keep,allowobfuscation class tv.abema.flagfit.annotation.DebugWith
+-keep,allowobfuscation class tv.abema.flagfit.annotation.ReleaseWith
+-keep,allowobfuscation class tv.abema.flagfit.annotation.DefaultWith
+-keep,allowobfuscation class tv.abema.flagfit.SuspendReturnType
 
-# Annotations must survive with their runtime values so Flagfit.create() can read
-# them via reflection at runtime.
--keepattributes RuntimeVisibleAnnotations,AnnotationDefault,Signature
+# Annotation values must survive at runtime so Flagfit.create() can read them
+# via reflection. Only RuntimeVisibleAnnotations belongs in consumer rules per
+# the Android library-optimization guidance — Flagfit does not read annotation
+# defaults or generic signatures, so AnnotationDefault and Signature are not
+# needed here.
+-keepattributes RuntimeVisibleAnnotations
 
-# Flagfit.create() builds a JDK Proxy for any interface whose methods are annotated
-# with @BooleanFlag or @VariationFlag, then iterates declaredMethods. R8 fullMode
-# removes such interfaces because it sees no concrete implementation, so explicitly
-# keep them. (Same pattern Retrofit uses for @retrofit2.http.* methods.)
+# Flagfit.create() builds a JDK Proxy for any interface whose methods are
+# annotated with @BooleanFlag or @VariationFlag, then iterates declaredMethods.
+# R8 fullMode removes such interfaces because it sees no concrete
+# implementation, so explicitly keep them.
+#
+# NOTE: do NOT add ,allowshrinking here. Although Retrofit ships its
+# equivalent rule with allowshrinking, empirically adding it causes R8
+# fullMode to tree-shake the annotated methods on user flag-service
+# interfaces (because the only dynamic caller is Proxy.invoke via reflection,
+# which R8 does not trace), which re-introduces the issue this rule fixes.
 -if interface * { @tv.abema.flagfit.annotation.BooleanFlag <methods>; }
 -keep,allowobfuscation interface <1>
 
@@ -36,6 +52,9 @@
     @tv.abema.flagfit.annotation.DefaultWith <methods>;
 }
 
-# FlagSource subclasses referenced only via @DebugWith / @ReleaseWith / @DefaultWith
-# (KClass<out FlagSource> annotation values) are otherwise unreachable.
--keep class * extends tv.abema.flagfit.FlagSource
+# FlagSource subclasses referenced only via @DebugWith / @ReleaseWith /
+# @DefaultWith (KClass<out FlagSource> annotation values) are otherwise
+# unreachable. allowobfuscation is safe (R8 rewrites class literals); do NOT
+# add allowshrinking — under R8 fullMode KClass annotation values are not
+# always traced as live references and dropping them would re-introduce #39.
+-keep,allowobfuscation class * extends tv.abema.flagfit.FlagSource


### PR DESCRIPTION
## Summary

Fixes #39. Under R8 fullMode (default since AGP 8.0) `Flagfit.create()` throws `ClassCastException` at startup because the user's flag-service interfaces, their annotated methods, and the `FlagSource` subclasses referenced only via `@DebugWith` / `@ReleaseWith` / `@DefaultWith` are tree-shaken away.

This change ships consumer ProGuard rules in both `flagfit` and `flagfit-flagtype` so apps need no extra ProGuard configuration. The rules are cross-checked against the Android Developers [library-optimization guide](https://developer.android.com/topic/performance/app-optimization/library-optimization) and the R8 [redundant-rules](https://developer.android.com/agents/skills/performance/r8-analyzer/references/REDUNDANT-RULES) / [reflection-guide](https://developer.android.com/agents/skills/performance/r8-analyzer/references/REFLECTION-GUIDE) / [keep-rules-impact-hierarchy](https://developer.android.com/agents/skills/performance/r8-analyzer/references/KEEP-RULES-IMPACT-HIERARCHY) references and tightened to match the official anti-bloat guidance:

- `flagfit/src/main/resources/META-INF/proguard/flagfit.pro`
  - Each of the six flagfit annotations and `SuspendReturnType` are kept individually with `-keep,allowobfuscation` (no library-package wildcards, per the library-optimization anti-pattern).
  - `-keepattributes` trimmed to `RuntimeVisibleAnnotations` only — `AnnotationDefault` / `Signature` belong in build rules and Flagfit reads neither default annotation values nor generic type signatures via reflection.
  - Conditional `-if interface * { @BooleanFlag/@VariationFlag <methods>; } -keep,allowobfuscation interface <1>` keeps any flag-service interface so `Proxy.newProxyInstance` has something to proxy. We deliberately do **not** add `,allowshrinking` here: although Retrofit's equivalent rule uses `,allowshrinking`, empirically adding it causes R8 fullMode to tree-shake the annotated methods on user flag-service interfaces (their only dynamic caller is `Proxy.invoke` via reflection, which R8 does not trace) — reproducing the very bug this rule fixes. An inline comment in `flagfit.pro` records the trade-off.
  - Sub-interfaces of an annotated parent are kept the same way (`interface * extends <1>`) so `Flagfit.create<Child>()` works when annotations live on the parent.
  - `-keepclassmembers,allowobfuscation interface * { @BooleanFlag <methods>; ... }` keeps the annotated methods so `Method.getAnnotations()` returns real values.
  - `-keep,allowobfuscation class * extends tv.abema.flagfit.FlagSource` keeps subclasses referenced only via annotation values. `,allowshrinking` is intentionally omitted — R8 fullMode does not always trace `KClass<out FlagSource>` annotation values as live references.
- `flagfit-flagtype/src/main/resources/META-INF/proguard/flagfit-flagtype.pro` (new) — keep `FlagType` and its inner annotation / `AnnotationAdapter` classes with `-keep,allowobfuscation` so R8 can rename them.
- `README.md` — document the new R8 / ProGuard story and provide a fallback snippet for users on older versions, kept in sync with the bundled rules.

## Test plan

- [x] Build a sample app with `android.enableR8.fullMode=true` and `isMinifyEnabled=true`, then verify `Flagfit.create()` no longer throws `ClassCastException` at startup.
- [x] Verify `@DebugWith` / `@ReleaseWith` / `@DefaultWith`-referenced `FlagSource` subclasses are retained in the shrunk bundle.
- [x] Verify a sub-interface of an annotated flag service (`interface Child : Parent`) can still be proxied through `Flagfit.create(Child::class)` after shrinking.
- [x] Re-verify after the library-optimization-driven refinements (commit `f069e3d`) that all of the above still hold.

## Verification results

Tested by temporarily flipping `sample-android` to `minifyEnabled true` and running `./gradlew :sample-android:assembleRelease` against the AGP 8.7.2 toolchain (R8 fullMode is the default — `gradle.properties` does not set `android.enableR8.fullMode=false`). The temporary `sample-android` changes have been reverted and are **not** part of this PR.

### With the new consumer rules — `BUILD SUCCESSFUL`

`mapping.txt` and `apkanalyzer dex code` confirm:

- `SampleFlagService` interface kept and all 6 annotated methods preserved (renamed `a`–`f`):
  ```
  tv.abema.fragfit.SampleFlagService -> Z0.c:
      boolean awesomeOpsFeatureEnabled() -> a
      boolean awesomeWipFeatureEnabled() -> b
      boolean awesomePermissionFeatureEnabled() -> c
      boolean awesomeExperimentFeatureEnabled() -> d
      boolean awesomeDebugFeatureEnabled() -> e
      boolean awesomeUnknownFeatureEnabled() -> f
  ```
- `JustFlagSource$True` / `$False` retained in DEX (renamed `Y0.n` / `Y0.l`).
- `FlagType` outer class + all four inner annotation classes + all four `*AnnotationAdapter` inner classes retained (renamed under `Y0.g$*`).
- The six flagfit annotations renamed to `Z0.a`–`Z0.f`, with their abstract members preserved by `-keepattributes RuntimeVisibleAnnotations`.

### Sub-interface case

Temporarily added `ParentFlagService` (with `@BooleanFlag` + `@DebugWith` + `@ReleaseWith`) and `ChildFlagService : ParentFlagService` to `sample-android`, with `MainActivity` calling `flagfit.create<ChildFlagService>()`. R8 fullMode output:

- Both interfaces kept (`ParentFlagService -> a1.d`, `ChildFlagService -> a1.a`).
- R8 **synthesises the inherited annotated method on the child interface** so `Child.declaredMethods` returns it directly. The DEX shows:
  ```smali
  .class public interface abstract La1/a;
  .implements La1/d;
  .method public abstract synthetic a()Z
      .annotation runtime LZ0/b; ...    # @BooleanFlag
      .annotation runtime LZ0/c;        # @DebugWith
          value = LY0/n;                # JustFlagSource$True
      .annotation runtime LZ0/e;        # @ReleaseWith
          value = LY0/l;                # JustFlagSource$False
  ```
  All three runtime annotations on the parent's method are preserved on the child's synthetic method, with their `KClass<out FlagSource>` values intact.

### Control: rules emptied — reproduces #39

Emptied `flagfit.pro` and removed `flagfit-flagtype.pro`, then rebuilt with `--rerun-tasks`:

- `awesome*Enabled() -> ` count in `mapping.txt`: **0** (every `SampleFlagService` method tree-shaken).
- `JustFlagSource$True` / `JustFlagSource$StringSource` / all `FlagType$*AnnotationAdapter` classes — absent from the DEX.
- For the sub-interface scenario, both `ParentFlagService` and `ChildFlagService` disappear entirely from `mapping.txt`.

This is exactly the runtime failure described in #39: `serviceClass.declaredMethods` returns an empty array and the `KClass<out FlagSource>` annotation values point at classes that no longer exist. The bundled rules eliminate both causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)