### PR TITLE
docs: bump README dependency version to 1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ allprojects {
 ```groovy
 dependencies {
     // Flagfit
-    implementation 'com.github.abema.flagfit:flagfit:1.1.5'
+    implementation 'com.github.abema.flagfit:flagfit:1.1.8'
     // Flagfit flagtype
-    implementation 'com.github.abema.flagfit:flagfit-flagtype:1.1.5'
+    implementation 'com.github.abema.flagfit:flagfit-flagtype:1.1.8'
     // Flagfit lint
-    lintChecks 'com.github.abema.flagfit:flagfit-lint:1.1.5'
+    lintChecks 'com.github.abema.flagfit:flagfit-lint:1.1.8'
 }
 ```
 


### PR DESCRIPTION
## Summary

Bump the README install snippet from `1.1.5` to `1.1.8`.

The documented Gradle coordinates had been left at `1.1.5` through the `1.1.6` and `1.1.7` releases. This brings them in line with the upcoming `1.1.8` release, which ships the R8 fullMode-correct consumer ProGuard rules from #41 (fixes #39).

Only the three dependency lines change; `sample-android`'s unrelated `androidx.test.ext:junit:1.1.5` is intentionally left untouched.

## Why now

This lands before tagging `1.1.8` so the tagged commit's README documents the matching version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)